### PR TITLE
fix eslint config for react-native plugin and standardize quotes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,17 +1,17 @@
-import { defineConfig } from "eslint/config";
-import js from "@eslint/js";
-import globals from "globals";
-import pluginReact from "eslint-plugin-react";
-import pluginReactNative from "eslint-plugin-react-native";
-import prettierPlugin from "eslint-plugin-prettier";
-import prettierConfig from "eslint-config-prettier";
+import { defineConfig } from 'eslint/config';
+import js from '@eslint/js';
+import globals from 'globals';
+import pluginReact from 'eslint-plugin-react';
+import pluginReactNative from 'eslint-plugin-react-native';
+import prettierPlugin from 'eslint-plugin-prettier';
+import prettierConfig from 'eslint-config-prettier';
 
 export default defineConfig([
   {
-    files: ["**/*.{js,mjs,cjs,jsx}"],
+    files: ['**/*.{js,mjs,cjs,jsx}'],
     languageOptions: {
-      ecmaVersion: "latest",
-      sourceType: "module",
+      ecmaVersion: 'latest',
+      sourceType: 'module',
       globals: {
         ...globals.browser,
         ...globals.node,
@@ -19,15 +19,18 @@ export default defineConfig([
     },
     plugins: {
       react: pluginReact,
-      "react-native": pluginReactNative,
+      'react-native': pluginReactNative,
       prettier: prettierPlugin,
     },
     rules: {
       ...js.configs.recommended.rules,
       ...pluginReact.configs.recommended.rules,
-      ...pluginReactNative.configs.recommended.rules,
-      "react/react-in-jsx-scope": "off",
-      "prettier/prettier": "error",
+      'react-native/no-unused-styles': 'error',
+      'react-native/no-inline-styles': 'warn',
+      'react-native/no-color-literals': 'warn',
+      'react-native/no-raw-text': 'warn',
+      'react/react-in-jsx-scope': 'off',
+      'prettier/prettier': 'error',
     },
   },
   prettierConfig,


### PR DESCRIPTION
The error occurred because the react-native ESLint plugin doesn't export configs in the expected format for the new flat config system, causing pluginReactNative.configs.recommended.rules to be undefined. I fixed this by directly specifying the individual React Native rules (no-unused-styles, no-inline-styles, etc.) and standardized quotes to match the project's Prettier configuration.