### PR TITLE
Use TestFlight for staging

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -15,9 +15,12 @@
       }
     },
     "staging": {
-      "distribution": "internal",
+      "android": {
+        "distribution": "internal"
+      },
       "channel": "staging",
       "ios": {
+        "distribution": "store",
         "resourceClass": "m-medium"
       },
       "env": {


### PR DESCRIPTION
Expo internal iOS builds use [Ad hoc Apple Developer Profile or Enterprise](https://docs.expo.dev/build/internal-distribution/#using-internal-distribution). We want to use TestFlight for staging for now.