### PR TITLE
Fix development workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,8 @@ SHELL [ "/bin/bash", "-c" ]
 # Force bash as OCI doesn't contain SHELL, so not in Podman https://docs.podman.io/en/latest/markdown/podman-build.1.html#format
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
+COPY .nvmrc .
+
 RUN \
   # nounset - Treat unset variables as an error when substituting
   # xtrace - Print commands and their arguments as they are executed
@@ -26,21 +28,7 @@ RUN \
   sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
   dpkg-reconfigure --frontend=noninteractive locales && \
   update-locale LANG=en_US.UTF-8 && \
-  # user setup
-  useradd --create-home --user-group --shell /bin/bash developer
-
-# npm < 9 changes user running process to match folder https://github.com/npm/cli/issues/4589
-USER developer
-
-WORKDIR /home/developer
-
-COPY .nvmrc .
-
-RUN \
-  # nounset - Treat unset variables as an error when substituting
-  # xtrace - Print commands and their arguments as they are executed
-  set -o nounset -o xtrace && \
-  # Install nodejs 16
+  # Install nodejs
   bash -c "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash" && \
   source ~/.bashrc && \
   # "source ~/.nvm/nvm.sh" fails if node isn't installed

--- a/src/utils/toolbox.js
+++ b/src/utils/toolbox.js
@@ -295,7 +295,7 @@ export const getDataOrigin = ({ domain, protocol=`https`, env }={}) => {
 
   if(env ? env === 'dev' : __DEV__) {
     // dev environment
-    return `${protocol.replace(/s$/, '')}://${DEV_DATA_ORIGIN_OVERRIDE || `localhost`}:8080`
+    return `${protocol}://${DEV_DATA_ORIGIN_OVERRIDE || `localhost`}`
   }
 
   if(env ? env === 'staging' : isStaging()) {

--- a/tenants/dummy/app.json
+++ b/tenants/dummy/app.json
@@ -16,7 +16,7 @@
       "REQUEST_OPTIONS": {},
       "AMPLITUDE_API_KEY": "",
       "ALLOW_INSECURE_LOCALHOST": true,
-      "QUOTES_DOMAIN": "q.toadreader.com",
+      "QUOTES_DOMAIN": "q.read.test",
       "VERSION_BUCKET": "bucket-versions-booklane"
     },
     "revisionId": "1",

--- a/tenants/dummy/app.json
+++ b/tenants/dummy/app.json
@@ -1,6 +1,7 @@
 {
   "expo": {
     "extra": {
+      "DEV_DATA_ORIGIN_OVERRIDE": "data.stg.read.test",
       "IDPS": {
         "21": {
           "name": "Toad Reader",


### PR DESCRIPTION
@biblemesh/puente-global These changes when used with https://github.com/biblemesh/toad-reader-server/pull/36 result in a fully working development environment when using the commands below. There may be changes to make it better suited for standalone development, but please try running this as a start, particularly for app development. The review process can be used to improve on this, but hopefully this enables development to continue.

Create the external volume for caddy's certificates:
```
docker volume create caddy-data
```

From https://github.com/biblemesh/toad-reader-server/pull/36
```
docker compose --file docker-compose.yml --file docker-compose-override.yml up
```

contents of docker-compose-override.yml below:
```
services:
  caddy:
    image: biblemesh/caddy:latest
    build:
      dockerfile_inline: |
        FROM caddy:builder AS builder

        RUN \
          # nounset - Treat unset variables as an error when substituting
          # xtrace - Print commands and their arguments as they are executed
          set -o nounset -o xtrace && \
          xcaddy build \
            --with github.com/caddyserver/transform-encoder \
            --with github.com/caddyserver/forwardproxy \
            --with github.com/caddyserver/replace-response

        FROM caddy

        COPY --from=builder /usr/bin/caddy /usr/bin/caddy
    pull_policy:
      build

  reader:
    image: biblemesh/toad-reader-server:1.0.0
    pull_policy: build
```

Using toad-reader-apps from this branch, I'm running it with `npm run start` followed by `w` to start the web development.

To extract the root certificate from caddy-data, please use `docker run --rm --user root --volume caddy-data:/backup-volume --volume ./:/backup busybox tar -zcvf /backup/caddy-data.tar.gz /backup-volume`, extract `caddy-data.tar.gz` and obtain it from `backup-volume/caddy/pki/authorities/local/root.crt`. This root certificate will need to be added to your trust store, but is unique to your device.

If you're still experiencing problems, please delete your volumes and some images to ensure that its using the latest setup, e.g. `docker compose down --volumes` and `docker rmi biblemesh/shibboleth-common:1.0.0-dev`.

![chrome_DVcFtxdxt4](https://github.com/user-attachments/assets/4a52ae47-93de-49c0-b677-daca2cd5d41e)
