### PR TITLE
fix logout issue for ios

### DIFF
--- a/src/components/major/AppMenu.js
+++ b/src/components/major/AppMenu.js
@@ -187,12 +187,16 @@ const AppMenu = ({
 
       const doLogOut = () => {
         logEvent({ eventName: `Log out` })
-        historyGoBack()
-        setTimeout(() => {
-          historyReplace("/", {
-            logOutAccountId: accountId,
-          })
-        }, 100)
+        // Use requestAnimationFrame to ensure state updates are properly batched
+        requestAnimationFrame(() => {
+          historyGoBack()
+          // Increase timeout to allow for proper cleanup
+          setTimeout(() => {
+            historyReplace("/", {
+              logOutAccountId: accountId,
+            })
+          }, 200)
+        })
       }
 
       if(Platform.OS === 'web') {
@@ -214,20 +218,29 @@ const AppMenu = ({
               
               setLoading(true)  // timeout needed after this to allow it to show
 
-              setTimeout(async () => {
-                await removeAccountEPubs(
-                  {
-                    books,
-                    removeFromBookDownloadQueue,
-                    setDownloadStatus,
-                    clearTocAndSpines,
-                    clearUserDataExceptProgress,
-                  },
-                )
+              // Use requestAnimationFrame to ensure proper batching of state updates
+              requestAnimationFrame(() => {
+                setTimeout(async () => {
+                  try {
+                    await removeAccountEPubs(
+                      {
+                        books,
+                        removeFromBookDownloadQueue,
+                        setDownloadStatus,
+                        clearTocAndSpines,
+                        clearUserDataExceptProgress,
+                      },
+                    )
 
-                setLoading(false)
+                    setLoading(false)
 
-                doLogOut()
+                    doLogOut()
+                  } catch (error) {
+                    console.error('Error during logout:', error)
+                    setLoading(false)
+                    doLogOut()
+                  }
+                }, 50)
               })
 
             },

--- a/src/components/screens/Library.js
+++ b/src/components/screens/Library.js
@@ -494,23 +494,39 @@ const Library = ({
 
   const logOutOnLoad = useCallback(
     async ({ accountId = logOutAccountId } = {}) => {
-      const { idpId } = getIdsFromAccountId(accountId);
-      const idp = idps[idpId];
-      const dataOrigin = getDataOrigin(idp);
+      try {
+        const { idpId } = getIdsFromAccountId(accountId);
+        const idp = idps[idpId];
+        const dataOrigin = getDataOrigin(idp);
 
-      // make sure the logout callback gets called (safari wasn't doing so; might be a race condition)
-      const logOutCallbackUrl = `${dataOrigin}/logout/callback?noredirect=1`;
-      await safeFetch(
-        logOutCallbackUrl,
-        getReqOptionsWithAdditions({
-          headers: {
-            'x-cookie-override': accounts[accountId].cookie,
-          },
-        }),
-      );
+        // make sure the logout callback gets called (safari wasn't doing so; might be a race condition)
+        const logOutCallbackUrl = `${dataOrigin}/logout/callback?noredirect=1`;
+        await safeFetch(
+          logOutCallbackUrl,
+          getReqOptionsWithAdditions({
+            headers: {
+              'x-cookie-override': accounts[accountId].cookie,
+            },
+          }),
+        );
 
-      removeAccount({ accountId });
-      historyReplace();
+        // Use requestAnimationFrame to batch state updates and prevent React warnings
+        requestAnimationFrame(() => {
+          removeAccount({ accountId });
+          setTimeout(() => {
+            historyReplace();
+          }, 50);
+        });
+      } catch (error) {
+        console.error('Error during logout:', error);
+        // Still perform cleanup even if network call fails
+        requestAnimationFrame(() => {
+          removeAccount({ accountId });
+          setTimeout(() => {
+            historyReplace();
+          }, 50);
+        });
+      }
     },
     [idps, accounts, logOutAccountId],
   );
@@ -529,10 +545,21 @@ const Library = ({
           setShowLoading(true);
           try {
             await logOutOnLoad({ accountId });
-            historyGoBackToLibrary();
-          } catch (err) {}
-          setShowLogin(true);
-          setShowLoading(false);
+            // Use requestAnimationFrame to batch state updates
+            requestAnimationFrame(() => {
+              historyGoBackToLibrary();
+              setTimeout(() => {
+                setShowLogin(true);
+                setShowLoading(false);
+              }, 50);
+            });
+          } catch (err) {
+            console.error('Error during auto-logout:', err);
+            requestAnimationFrame(() => {
+              setShowLogin(true);
+              setShowLoading(false);
+            });
+          }
         })();
         return;
       }


### PR DESCRIPTION
closes https://github.com/biblemesh/ereader-development/issues/85
This PR fixes a crash triggered during the logout flow where SideMenu unmounts and calls onClose, causing state updates during React’s useInsertionEffect phase. To prevent this, all logout-related state updates (removeAccount, historyReplace, and loading transitions) are now deferred using requestAnimationFrame and small timeouts. This ensures that updates run only after the layout and style injection steps have completed. As a result, the logout process is now stable across iOS, Android, and Web with no crashes.
