### PR TITLE
Greatly simplify staging docker setup

### DIFF
--- a/.devcontainer/staging/docker-compose.yml
+++ b/.devcontainer/staging/docker-compose.yml
@@ -33,7 +33,13 @@ services:
     image: biblemesh/toad-reader-apps:latest
     build:
       context: ../../
-      dockerfile: ./.devcontainer/development/Dockerfile
+      dockerfile_inline:
+        FROM node:${NODE_VERSION:-20}-alpine
+
+        RUN
+          set -o nounset -o xtrace &&
+          apk add bash &&
+          npm config set script-shell bash
     command: ["/bin/bash", "-c", "sleep infinity"]
     networks:
       - ereader

--- a/.devcontainer/staging/docker-compose.yml
+++ b/.devcontainer/staging/docker-compose.yml
@@ -5,8 +5,7 @@ services:
   caddy:
     build:
       context: .
-      dockerfile_inline:
-        FROM caddy:2-builder-alpine AS builder
+      dockerfile_inline: FROM caddy:2-builder-alpine AS builder
 
         RUN xcaddy build --with github.com/caddyserver/forwardproxy
 
@@ -33,14 +32,8 @@ services:
     image: biblemesh/toad-reader-apps:latest
     build:
       context: ../../
-      dockerfile_inline:
-        FROM node:${NODE_VERSION:-20}-alpine
-
-        RUN
-          set -o nounset -o xtrace &&
-          apk add bash &&
-          npm config set script-shell bash
-    command: ["/bin/bash", "-c", "sleep infinity"]
+      dockerfile: ./.devcontainer/development/Dockerfile
+    command: ['/bin/bash', '-c', 'sleep infinity']
     networks:
       - ereader
     pull_policy: build

--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -5,7 +5,7 @@ on:
 
 
 env:
-  DEFAULT_NODE_VERSION: 18
+  DEFAULT_NODE_VERSION: 20  # FIXME use nvmrc instead
 
 permissions:
   contents: read

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
 services:
   ereader-frontend:
-    command: ["bash", "-c", "source /root/.nvm/nvm.sh; npm run start"]
+    image: node:${NODE_VERSION:-20}-alpine
+    command: ['npm', 'start']
     ports:
-      - "19006:19006"
+      - '19006:19006'
     volumes:
       - ../../:/app
     working_dir: /app
+    pull_policy: always

--- a/package.json
+++ b/package.json
@@ -1,69 +1,72 @@
 {
   "name": "toad-reader-apps",
   "version": "1.0.0",
+  "private": true,
   "description": "Toad Reader Apps",
   "author": "Andy Hubert",
-  "private": true,
   "main": "node_modules/expo/AppEntry.js",
-  "engines": {
-    "node": ">=20.0.0"
-  },
   "scripts": {
-    "start-staging": "NODE_VERSION=$(cat .nvmrc) docker compose -f .devcontainer/staging/docker-compose.yml -f docker-compose.yml up",
     "android": "npx expo start --android",
-    "build-android-development": "(node ./scripts/echoActionToPerform.js --action build-android-development && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform android --profile development) || npm run post-push-restore)) || true",
-    "build-android-staging": "(node ./scripts/echoActionToPerform.js --action build-android-staging && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform android --profile staging) || npm run post-push-restore)) || true",
     "build-android-beta": "(node ./scripts/echoActionToPerform.js --action build-android-beta && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform android --profile beta) || npm run post-push-restore)) || true",
+    "build-android-development": "(node ./scripts/echoActionToPerform.js --action build-android-development && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform android --profile development) || npm run post-push-restore)) || true",
     "build-android-production": "(node ./scripts/echoActionToPerform.js --action build-android-production && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform android --profile production) || npm run post-push-restore)) || true",
-    "build-ios-development": "(node ./scripts/echoActionToPerform.js --action build-ios-development && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform ios --profile development) || npm run post-push-restore)) || true",
-    "build-ios-staging": "(node ./scripts/echoActionToPerform.js --action build-ios-staging && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform ios --profile staging) || npm run post-push-restore)) || true",
-    "build-ios-beta": "(node ./scripts/echoActionToPerform.js --action build-ios-beta && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform ios --profile beta) || npm run post-push-restore)) || true",
-    "build-ios-production": "(node ./scripts/echoActionToPerform.js --action build-ios-production && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform ios --profile production) || npm run post-push-restore)) || true",
+    "build-android-staging": "(node ./scripts/echoActionToPerform.js --action build-android-staging && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform android --profile staging) || npm run post-push-restore)) || true",
     "build-apps-production": "(node ./scripts/echoActionToPerform.js --action build-apps-production && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform all --profile production) || npm run post-push-restore)) || true",
-    "submit-android-production": "echo '\n\nINSTRUCTIONS: Download the latest Android build from Expo and upload it to the Play Store.\n'",
-    "submit-ios-production": "(node ./scripts/echoActionToPerform.js --action submit-ios-production && npm run confirm -s && (npx eas-cli submit --platform ios --profile production --latest)) || true",
+    "build-ios-beta": "(node ./scripts/echoActionToPerform.js --action build-ios-beta && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform ios --profile beta) || npm run post-push-restore)) || true",
+    "build-ios-development": "(node ./scripts/echoActionToPerform.js --action build-ios-development && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform ios --profile development) || npm run post-push-restore)) || true",
+    "build-ios-production": "(node ./scripts/echoActionToPerform.js --action build-ios-production && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform ios --profile production) || npm run post-push-restore)) || true",
+    "build-ios-staging": "(node ./scripts/echoActionToPerform.js --action build-ios-staging && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform ios --profile staging) || npm run post-push-restore)) || true",
+    "change-tenant": "./scripts/changeTenant.sh",
     "ci:build": "npm run change-tenant dummy && npx expo prebuild --clean",
     "ci:lint": "npm run lint",
-    "change-tenant": "./scripts/changeTenant.sh",
     "confirm": "read -p 'Are you sure? (y/N) ' -n 1 -r && echo '\n' && [[ $REPLY =~ ^[Yy]$ ]]",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "go-push-apps-to-production": "npm run pre-push-swap && npx eas-cli update --auto --branch production && npm run post-push-restore",
+    "go-push-web-to-staging": "npm run pre-push-swap && npx expo export:web && cp -r web-build-overrides/* web-build && node ./scripts/pushWebToStaging.js && npm run post-push-restore",
     "ios": "npx expo start --ios",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "list-versions": "node ./scripts/listVersions.js",
-    "pre-push-swap": "sed --in-place=.orig \"s/PUSH_DATE_STRING/$(date '+%b %d, %Y at %H:%M')/g\" src/components/major/AppMenu.js",
     "post-push-restore": "rm src/components/major/AppMenu.js && mv src/components/major/AppMenu.js.orig src/components/major/AppMenu.js",
-    "push-apps-to-staging": "(node ./scripts/echoActionToPerform.js --action push-apps-to-staging && npm run confirm -s && npm run pre-push-swap && npx eas-cli update --auto --branch staging && npm run post-push-restore) || true",
+    "pre-push-swap": "sed --in-place=.orig \"s/PUSH_DATE_STRING/$(date '+%b %d, %Y at %H:%M')/g\" src/components/major/AppMenu.js",
+    "prepare": "npx husky",
+    "push-all-to-production": "(node ./scripts/echoActionToPerform.js --action push-all-to-production && npm run confirm -s && npm run go-push-web-to-staging && node ./scripts/pushwebstagingtoproduction.js && npm run go-push-apps-to-production) || true",
     "push-apps-to-beta": "(node ./scripts/echoActionToPerform.js --action push-apps-to-beta && npm run confirm -s && npm run pre-push-swap && npx eas-cli update --auto --branch beta && npm run post-push-restore) || true",
     "push-apps-to-production": "(node ./scripts/echoActionToPerform.js --action push-apps-to-production && npm run confirm -s && npm run go-push-apps-to-production) || true",
-    "go-push-apps-to-production": "npm run pre-push-swap && npx eas-cli update --auto --branch production && npm run post-push-restore",
     "push-apps-to-production-all-tenants": "(node ./scripts/echoActionToPerform.js --action push-apps-to-production-all-tenants && npm run confirm -s && ./scripts/pushAppsToProductionAllTenants.sh) || true",
-    "push-web-to-staging": "(node ./scripts/echoActionToPerform.js --action push-web-to-staging && npm run confirm -s && npm run go-push-web-to-staging) || true",
-    "go-push-web-to-staging": "npm run pre-push-swap && npx expo export:web && cp -r web-build-overrides/* web-build && node ./scripts/pushWebToStaging.js && npm run post-push-restore",
-    "push-web-to-beta": "(node ./scripts/echoActionToPerform.js --action push-web-to-beta && npm run confirm -s && npm run pre-push-swap && npx expo export:web && cp -r web-build-overrides/* web-build && node ./scripts/pushWebToBeta.js && npm run post-push-restore) || true",
-    "push-web-staging-to-production": "(node ./scripts/echoActionToPerform.js --action push-web-staging-to-production && npm run confirm -s && node ./scripts/pushWebStagingToProduction.js) || true",
+    "push-apps-to-staging": "(node ./scripts/echoActionToPerform.js --action push-apps-to-staging && npm run confirm -s && npm run pre-push-swap && npx eas-cli update --auto --branch staging && npm run post-push-restore) || true",
     "push-web-beta-to-production": "(node ./scripts/echoActionToPerform.js --action push-web-beta-to-production && npm run confirm -s && node ./scripts/pushWebBetaToProduction.js) || true",
+    "push-web-staging-to-production": "(node ./scripts/echoActionToPerform.js --action push-web-staging-to-production && npm run confirm -s && node ./scripts/pushWebStagingToProduction.js) || true",
+    "push-web-to-beta": "(node ./scripts/echoActionToPerform.js --action push-web-to-beta && npm run confirm -s && npm run pre-push-swap && npx expo export:web && cp -r web-build-overrides/* web-build && node ./scripts/pushWebToBeta.js && npm run post-push-restore) || true",
     "push-web-to-production-all-tenants": "(node ./scripts/echoActionToPerform.js --action push-web-to-production-all-tenants && npm run confirm -s && ./scripts/pushWebToProductionAllTenants.sh) || true",
-    "push-all-to-production": "(node ./scripts/echoActionToPerform.js --action push-all-to-production && npm run confirm -s && npm run go-push-web-to-staging && node ./scripts/pushwebstagingtoproduction.js && npm run go-push-apps-to-production) || true",
+    "push-web-to-staging": "(node ./scripts/echoActionToPerform.js --action push-web-to-staging && npm run confirm -s && npm run go-push-web-to-staging) || true",
     "remind": "read -p 'Did you update the version number and rerun change-tenant? (y/N) ' -n 1 -r && echo '\n' && [[ $REPLY =~ ^[Yy]$ ]]",
-    "rollback-web": "node ./scripts/rollBackWeb.js",
     "rollback-apps": "npx eas-cli update:republish --branch production",
+    "rollback-web": "node ./scripts/rollBackWeb.js",
+    "start": "GENERATE_SOURCEMAP=false npx expo start --port 19006",
+    "start-staging": "NODE_VERSION=$(cat .nvmrc) docker compose -f .devcontainer/staging/docker-compose.yml -f docker-compose.yml up",
+    "submit-android-production": "echo '\n\nINSTRUCTIONS: Download the latest Android build from Expo and upload it to the Play Store.\n'",
+    "submit-ios-production": "(node ./scripts/echoActionToPerform.js --action submit-ios-production && npm run confirm -s && (npx eas-cli submit --platform ios --profile production --latest)) || true",
     "translate": "node node_modules/inline-i18n/scripts/makeTranslationFiles.js --translations-dir='./src/utils/translations' --translation-file-exclude-regex='current.json' && npm run translate-convert-json-to-csv",
     "translate-convert-csv-to-json": "node node_modules/inline-i18n/scripts/convertTranslationCSVtoJSON.js --translations-dir='./src/utils/translations'",
     "translate-convert-json-to-csv": "node node_modules/inline-i18n/scripts/convertTranslationJSONtoCSV.js --translations-dir='./src/utils/translations'",
-    "start": "GENERATE_SOURCEMAP=false npx expo start --port 19006",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "format": "prettier --write .",
-    "format:check": "prettier --check .",
-    "prepare": "npx husky",
     "update-indirect-dependencies": "npx update-browserslist-db@latest"
   },
   "lint-staged": {
-    "*.+(json|css|md|scss)": [
+    "*.+(json|css|md|scss|yml|yaml)": [
       "prettier --write"
     ],
     "*.+(js|jsx|ts|tsx|mjs)": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "*.json": [
+      "jsonsort"
     ]
+  },
+  "overrides": {
+    "react-native-webview": "13.13.5"
   },
   "dependencies": {
     "@amplitude/analytics-react-native": "^1.1.1",
@@ -160,7 +163,7 @@
     "prettier": "^3.5.3",
     "typescript-eslint": "^8.38.0"
   },
-  "overrides": {
-    "react-native-webview": "13.13.5"
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
+    "start-staging": "NODE_VERSION=$(cat .nvmrc) docker compose -f .devcontainer/staging/docker-compose.yml -f docker-compose.yml up",
     "android": "npx expo start --android",
     "build-android-development": "(node ./scripts/echoActionToPerform.js --action build-android-development && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform android --profile development) || npm run post-push-restore)) || true",
     "build-android-staging": "(node ./scripts/echoActionToPerform.js --action build-android-staging && npm run remind -s && ((npm run pre-push-swap && npx eas-cli build --platform android --profile staging) || npm run post-push-restore)) || true",


### PR DESCRIPTION
Most of the contents of the Dockerfile in devcontainer is not useful for simply running the application. I propose the following:

* For those who want to use devcontainer, build the devcontainer as before, and run using `docker compose up` in the `.devcontainer/staging` directory
* For those who just want to run the expo server, simply do `npm install` then `npm run start-staging`