### PR TITLE
Fix: add Node 22 to CI matrix; remove Node 18

### DIFF
--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22]
         action: [build, lint] # , test]
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Node 18 is no longer used, so update CI matrix to include Node 22 and remove Node 18