### PR TITLE
Revert "Bump d3-color, victory and victory-native"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "react-native-circular-progress": "1.3.7",
         "react-native-flip-editor": "github:biblemesh/react-native-flip-editor#7bb67786ef504ca5694b757f915b0e883e6d7f26",
         "react-native-gesture-handler": "~2.24.0",
-        "react-native-reanimated": "~3.19.1",
+        "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-simple-side-menu": "github:biblemesh/react-native-simple-side-menu#23df42cad42ccfb276d29140d853864ed1af57a3",
         "react-native-svg": "15.11.2",
@@ -82,8 +82,8 @@
         "stream": "0.0.2",
         "timers": "0.1.1",
         "uuid": "^9.0.1",
-        "victory": "37.3.6",
-        "victory-native": "41.20.2",
+        "victory": "34.1.3",
+        "victory-native": "34.1.0",
         "vm-browserify": "^1.1.2",
         "xml2js": "0.4.23"
       },
@@ -3185,34 +3185,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@shopify/react-native-skia": {
-      "version": "2.4.14",
-      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-2.4.14.tgz",
-      "integrity": "sha512-zFxjAQbfrdOxoNJoaOCZQzZliuAWXjFkrNZv2PtofG2RAUPWIxWmk2J/oOROpTwXgkmh1JLvFp3uONccTXUthQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "canvaskit-wasm": "0.40.0",
-        "react-reconciler": "0.31.0"
-      },
-      "bin": {
-        "setup-skia-web": "scripts/setup-canvaskit.js"
-      },
-      "peerDependencies": {
-        "react": ">=19.0",
-        "react-native": ">=0.78",
-        "react-native-reanimated": ">=3.19.1"
-      },
-      "peerDependenciesMeta": {
-        "react-native": {
-          "optional": true
-        },
-        "react-native-reanimated": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "license": "MIT"
@@ -3275,69 +3247,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT"
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "license": "MIT",
@@ -3388,25 +3297,6 @@
       "version": "3.4.3",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/react": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
-      "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/react-reconciler": {
-      "version": "0.28.9",
-      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
-      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*"
-      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -3727,13 +3617,6 @@
       "peerDependencies": {
         "@urql/core": "^5.0.0"
       }
-    },
-    "node_modules/@webgpu/types": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
-      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
-      "license": "BSD-3-Clause",
-      "peer": true
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
@@ -4783,16 +4666,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/canvaskit-wasm": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.40.0.tgz",
-      "integrity": "sha512-Od2o+ZmoEw9PBdN/yCGvzfu0WVqlufBPEWNG452wY7E9aT8RBE+ChpZF526doOlg7zumO4iCS+RAeht4P0Gbpw==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@webgpu/types": "0.1.21"
-      }
-    },
     "node_modules/canvg": {
       "version": "3.0.11",
       "license": "MIT",
@@ -5371,9 +5244,7 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "version": "3.1.3",
       "license": "MIT"
     },
     "node_modules/csv-parser": {
@@ -5391,197 +5262,74 @@
       }
     },
     "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.2.4",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-collection": {
+      "version": "1.0.7",
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dispatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-drag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-selection": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.4.1",
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.0.7",
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.4.5",
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
+      "version": "1.4.0",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
+        "d3-color": "1"
       }
     },
     "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.0.9",
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
+      "version": "1.0.7",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-selection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
       }
     },
     "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
+      "version": "1.3.7",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
+        "d3-path": "1"
       }
     },
     "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "1.1.0",
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "license": "ISC",
+      "version": "2.3.0",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
+        "d3-time": "1"
       }
     },
     "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-transition": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-dispatch": "1 - 3",
-        "d3-ease": "1 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "d3-selection": "2 - 3"
-      }
+      "version": "1.0.10",
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-voronoi": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
-      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-zoom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "2 - 3",
-        "d3-transition": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -5721,14 +5469,10 @@
     },
     "node_modules/delaunator": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
-      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
       "license": "ISC"
     },
     "node_modules/delaunay-find": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
-      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
+      "version": "0.0.5",
       "license": "ISC",
       "dependencies": {
         "delaunator": "^4.0.0"
@@ -8091,15 +7835,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "license": "MIT",
@@ -8659,18 +8394,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/its-fine": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
-      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/react-reconciler": "^0.28.0"
-      },
-      "peerDependencies": {
-        "react": ">=18.0"
-      }
-    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "license": "BlueOak-1.0.0",
@@ -8935,12 +8658,6 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -11486,9 +11203,7 @@
       }
     },
     "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "version": "2.0.4",
       "license": "MIT"
     },
     "node_modules/react-is": {
@@ -11604,9 +11319,8 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.19.5",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.19.5.tgz",
-      "integrity": "sha512-bd4AwIkBAaY4BjrgpSoKjEaRG/tXD756F5nGuiH5IMBSKN8tRdUEA8hWZCyIo/R6/kha/tVSoCqodVUACh7ZWw==",
+      "version": "3.17.5",
+      "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -11804,22 +11518,6 @@
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
-      }
-    },
-    "node_modules/react-reconciler": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
-      "integrity": "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.25.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0"
       }
     },
     "node_modules/react-redux": {
@@ -14052,549 +13750,323 @@
       }
     },
     "node_modules/victory": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory/-/victory-37.3.6.tgz",
-      "integrity": "sha512-CZ1vjvra0R1U3T2dMI4EsjI8Ng+JmQ2ox/EweSzjkTnHfW/Vn5ylryadawDiYjDMcBvABjO3uODsIlSEm4d/Sw==",
+      "version": "34.1.3",
       "license": "MIT",
       "dependencies": {
-        "victory-area": "37.3.6",
-        "victory-axis": "37.3.6",
-        "victory-bar": "37.3.6",
-        "victory-box-plot": "37.3.6",
-        "victory-brush-container": "37.3.6",
-        "victory-brush-line": "37.3.6",
-        "victory-candlestick": "37.3.6",
-        "victory-canvas": "37.3.6",
-        "victory-chart": "37.3.6",
-        "victory-core": "37.3.6",
-        "victory-create-container": "37.3.6",
-        "victory-cursor-container": "37.3.6",
-        "victory-errorbar": "37.3.6",
-        "victory-group": "37.3.6",
-        "victory-histogram": "37.3.6",
-        "victory-legend": "37.3.6",
-        "victory-line": "37.3.6",
-        "victory-pie": "37.3.6",
-        "victory-polar-axis": "37.3.6",
-        "victory-scatter": "37.3.6",
-        "victory-selection-container": "37.3.6",
-        "victory-shared-events": "37.3.6",
-        "victory-stack": "37.3.6",
-        "victory-tooltip": "37.3.6",
-        "victory-voronoi": "37.3.6",
-        "victory-voronoi-container": "37.3.6",
-        "victory-zoom-container": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "victory-area": "^34.1.3",
+        "victory-axis": "^34.1.3",
+        "victory-bar": "^34.1.3",
+        "victory-box-plot": "^34.1.3",
+        "victory-brush-container": "^34.1.3",
+        "victory-brush-line": "^34.1.3",
+        "victory-candlestick": "^34.1.3",
+        "victory-chart": "^34.1.3",
+        "victory-core": "^34.1.3",
+        "victory-create-container": "^34.1.3",
+        "victory-cursor-container": "^34.1.3",
+        "victory-errorbar": "^34.1.3",
+        "victory-group": "^34.1.3",
+        "victory-legend": "^34.1.3",
+        "victory-line": "^34.1.3",
+        "victory-pie": "^34.1.3",
+        "victory-polar-axis": "^34.1.3",
+        "victory-scatter": "^34.1.3",
+        "victory-selection-container": "^34.1.3",
+        "victory-shared-events": "^34.1.3",
+        "victory-stack": "^34.1.3",
+        "victory-tooltip": "^34.1.3",
+        "victory-voronoi": "^34.1.3",
+        "victory-voronoi-container": "^34.1.3",
+        "victory-zoom-container": "^34.1.3"
       }
     },
     "node_modules/victory-area": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-37.3.6.tgz",
-      "integrity": "sha512-wVC8LKrZJLiSySNuJLRCB449qZTsPiRyzLlNoJwe21y+XA/a2HJbmJSeywmo8P153aX8viKe1H8ygDsTFXQhHw==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6",
-        "victory-vendor": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-axis": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-37.3.6.tgz",
-      "integrity": "sha512-Vi0dZvgmXmnCdoqc49WckeG5cMXnl7FTtqVhXu9JweA9cgCnkZabBd5mRvAjblb3Lo4j0HZCSPKHYWUPW70qZg==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-bar": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-37.3.6.tgz",
-      "integrity": "sha512-jdATFRWL1LUW/yEpKWx/aId2BiU2o1pPF9+Kh1TFISBduJoI4ZqvZD90H1QK4f/z50PikqiqiDECaKoKM1jfOQ==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6",
-        "victory-vendor": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-box-plot": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-37.3.6.tgz",
-      "integrity": "sha512-GOucnD63h14ScBuISC/nd1GBTEx6gIZfLE+0P0gyeH1poBKq0trTTvpQDvAMuGR8zICfEETG3ltmUMCwRrFyUg==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6",
-        "victory-vendor": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "d3-array": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-brush-container": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-37.3.6.tgz",
-      "integrity": "sha512-LfZ2CgX1cYAqCtYxcSB68OfZS2v0T2VLXoEArd0lCXfRBY1Gya7GacCUcuo7GoK9XOXeslx7S/U95aVutt1VLg==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-brush-line": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-37.3.6.tgz",
-      "integrity": "sha512-zsZJfF1fUj4F7mUoIMV+h73qoTClPA4bKM1terlYrDBD8l/c/f0KBbEotu3E1X+n4QMmDRruswaB/YUdqK5QLA==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-candlestick": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-37.3.6.tgz",
-      "integrity": "sha512-h/mOmkCrsWrirn4dFnpLxJPXpxT+uHxuYxnXGrAyH+YUOrVj3iKaDJlEiVlz5vy30syE5j5hzTQCMsZ/hzHNdg==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-canvas": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-37.3.6.tgz",
-      "integrity": "sha512-1CD4S0uZ92sUGGSIEQferEfSqd/z9EXw9G6zkzPIoJeTKFshpfqCjUkNRx9Iu9Upxt3fUpId8Qwl1YfchmbrFg==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-bar": "37.3.6",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-chart": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-37.3.6.tgz",
-      "integrity": "sha512-IkPo/W4AJ7bPu902TGER09OseR9ODm+FQAKfOBw4JsdEhZZ7BiG9zgd/25+x0r5EsTLu81CYGQVkBa+ZazcOlA==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-axis": "37.3.6",
-        "victory-core": "37.3.6",
-        "victory-polar-axis": "37.3.6",
-        "victory-shared-events": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-axis": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-polar-axis": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
       }
     },
     "node_modules/victory-core": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-37.3.6.tgz",
-      "integrity": "sha512-aFgO6KokxPbUCPznZP5UPhOdI22pMuwDXKDt6eoQOnkVim66Ia+K95TQar2nwVKGYV5j26aKVf/n9blwphGJRw==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.21",
-        "react-fast-compare": "^3.2.0",
-        "victory-vendor": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "d3-ease": "^1.0.0",
+        "d3-interpolate": "^1.1.1",
+        "d3-scale": "^1.0.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0"
       }
     },
     "node_modules/victory-create-container": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-37.3.6.tgz",
-      "integrity": "sha512-Uf5bFQvqUsXCjqpvBW4LhrdrHkM6dBqxYgub6FCsBb86f84xZQ3vY7jFkg/JfvF0oGKMoWXYYrYLC1sk+fcWVA==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-brush-container": "37.3.6",
-        "victory-core": "37.3.6",
-        "victory-cursor-container": "37.3.6",
-        "victory-selection-container": "37.3.6",
-        "victory-voronoi-container": "37.3.6",
-        "victory-zoom-container": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "victory-brush-container": "^34.3.12",
+        "victory-core": "^34.3.12",
+        "victory-cursor-container": "^34.3.12",
+        "victory-selection-container": "^34.3.12",
+        "victory-voronoi-container": "^34.3.12",
+        "victory-zoom-container": "^34.3.12"
       }
     },
     "node_modules/victory-cursor-container": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-37.3.6.tgz",
-      "integrity": "sha512-+Oiw57d5nE+iq8As8RvepknzmNtKq1Gsc50u1X3IRd4jXtX8zqZrgXGlVZ+BP/tkLsWnGYVjKulwKBf2oaEUuw==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-errorbar": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-37.3.6.tgz",
-      "integrity": "sha512-WGAv/qizOlfmwKv+Yfxr4q6pDgTfloNQwi3Z3M0h8povjMZt74tHYkvi/TASSRYr3zv5kjUqUJ28qAyGMWwryQ==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-group": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-37.3.6.tgz",
-      "integrity": "sha512-kgy/Azl5BxwlJAV0KDPGypv35TMrOD1J2ZxnJW2Wyyq+e8i0GGBIv5MoBzou64BRsDlS9V0CYRIjnkHgrBpB5w==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.6",
-        "victory-shared-events": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-histogram": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-37.3.6.tgz",
-      "integrity": "sha512-K4d43MpXHYnGCLEMzfRpJ+lCRRDKALPi/juxfMGVzBPzSMgjC8h9x6hKdxaejiTd/E04UdzNO7J24plL3Uz8rA==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-bar": "37.3.6",
-        "victory-core": "37.3.6",
-        "victory-vendor": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
       }
     },
     "node_modules/victory-legend": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-37.3.6.tgz",
-      "integrity": "sha512-vRRrhj3/ENqKVLdaBMzEmR83N6BOjox1bthYT1eJjN2H5SIK35bxn30IkiV/Pz3y627EqZe4TAWaxc0jiJlCiA==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-line": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-37.3.6.tgz",
-      "integrity": "sha512-Ke817uf/qFbN9jU7Dba7CrcHXYO5wAZuKKnyeHJmLDeQeFST0773xejnIuC+dBgZipjFr4KIbSd+VcUafFNE1g==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6",
-        "victory-vendor": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-native": {
-      "version": "41.20.2",
-      "resolved": "https://registry.npmjs.org/victory-native/-/victory-native-41.20.2.tgz",
-      "integrity": "sha512-gc6DPnfoAHYnaWndXfrITlBvKdLKtoq3J4muBn/Sawu528+MfByAI8LlJBboDGHE1rLBWsgiS58h67D3Ulmtqg==",
+      "version": "34.1.0",
       "license": "MIT",
       "dependencies": {
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.2.0",
-        "d3-zoom": "^3.0.0",
-        "its-fine": "^1.2.5",
-        "react-fast-compare": "^3.2.2"
-      },
-      "peerDependencies": {
-        "@shopify/react-native-skia": ">=1.2.3",
-        "react": "*",
-        "react-native": "*",
-        "react-native-gesture-handler": ">=2.0.0",
-        "react-native-reanimated": ">=3.0.0"
+        "lodash": "^4.17.11",
+        "prop-types": "^15.5.10",
+        "react-fast-compare": "^2.0.0",
+        "victory": "^34.1.1",
+        "victory-area": "^34.1.1",
+        "victory-axis": "^34.1.1",
+        "victory-bar": "^34.1.1",
+        "victory-box-plot": "^34.1.1",
+        "victory-brush-container": "^34.1.1",
+        "victory-brush-line": "^34.1.1",
+        "victory-candlestick": "^34.1.1",
+        "victory-chart": "^34.1.1",
+        "victory-core": "^34.1.1",
+        "victory-create-container": "^34.1.1",
+        "victory-cursor-container": "^34.1.1",
+        "victory-errorbar": "^34.1.1",
+        "victory-group": "^34.1.1",
+        "victory-legend": "^34.1.1",
+        "victory-line": "^34.1.1",
+        "victory-pie": "^34.1.1",
+        "victory-polar-axis": "^34.1.1",
+        "victory-scatter": "^34.1.1",
+        "victory-selection-container": "^34.1.1",
+        "victory-shared-events": "^34.1.1",
+        "victory-stack": "^34.1.1",
+        "victory-tooltip": "^34.1.1",
+        "victory-voronoi": "^34.1.1",
+        "victory-voronoi-container": "^34.1.1",
+        "victory-zoom-container": "^34.1.1"
       }
     },
     "node_modules/victory-pie": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-37.3.6.tgz",
-      "integrity": "sha512-tvdgAZ/HQWlo3KDDe0XAVbizHuaNMbgkkiF7zfA7Ww+3bHSs+0P9dsDtK2xP365D8gBCOv8pWmuzvKRhzNbqeA==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6",
-        "victory-vendor": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "d3-shape": "^1.0.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-polar-axis": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-37.3.6.tgz",
-      "integrity": "sha512-RpFsCkzHezJq5P+C/wtVdjEHX25JIFsSgs6qYSnfr/hayaFbWgK5HhRFpriQm5hg61cx47WxAOLyHvzf0nasvw==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-scatter": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-37.3.6.tgz",
-      "integrity": "sha512-fp95zMTPXgW1cmTowzDXhn+KxePMVDrzU0lotsHQMdBV7eB+ioXdu9hORlx4VHmMYg2ihsGwRTF+VAZ7rGxphA==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-selection-container": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-37.3.6.tgz",
-      "integrity": "sha512-gd3qODDlBtLEJM7+2jCXk2YcLBUmIpYEEHswytMhwc6zihxXipGBUHRulhLj/I05mKay2gaOAg5ewiJHd4Awgw==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-shared-events": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-37.3.6.tgz",
-      "integrity": "sha512-ygrbOtzLUTbtKebacZKyQRekhSAROnAvMkVI/PKsAGsz0ClY9P7qDEJG7eTUUygjO6ax0tI6WNE6JogQzeD1gw==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-stack": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-37.3.6.tgz",
-      "integrity": "sha512-ldod04RdqGJGH5p5eWXCofdTkbhZqIp3iwW7NpxSbMDLs8zPQIVvDFVtuJgMwQiC5vnIpbhMmxVeFbr8m64ZKA==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.6",
-        "victory-shared-events": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-shared-events": "^34.3.12"
       }
     },
     "node_modules/victory-tooltip": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-37.3.6.tgz",
-      "integrity": "sha512-vqaJS9noauOqDDBBAV9Ln9duOY/i17h1DCfCPAqhwPFyvFbwKvAub9zPTeYWAm/14VvWX5O/0yekFCVbcC7hjg==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
-      }
-    },
-    "node_modules/victory-vendor": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
-      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
-      "license": "MIT AND ISC",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-voronoi": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-37.3.6.tgz",
-      "integrity": "sha512-Q+1FWHp8IAbmDL9pGWS0y0N4Cb5qmD9OOgxoxCfIDsLlhGvd6LddhRoknWsN7WnreaK+XiwjSfQkdMTCZ4hdhQ==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "d3-voronoi": "^1.1.4",
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "d3-voronoi": "^1.1.2",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/victory-voronoi-container": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-37.3.6.tgz",
-      "integrity": "sha512-qAAG0rMuK7A4EoJ4cyUk5wNdOW+HuCXNKPOko+hYK6wWOYXJvFhiglYyA85a695YyAXECc6JyJS/crm4IOEFag==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "delaunay-find": "0.0.6",
-        "lodash": "^4.17.19",
-        "react-fast-compare": "^3.2.0",
-        "victory-core": "37.3.6",
-        "victory-tooltip": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "delaunay-find": "0.0.5",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "react-fast-compare": "^2.0.0",
+        "victory-core": "^34.3.12",
+        "victory-tooltip": "^34.3.12"
       }
     },
     "node_modules/victory-zoom-container": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-37.3.6.tgz",
-      "integrity": "sha512-AGL+k20mI44OL5b0VgIxlmnNSefIoFmbbim5NraPmIxbtns9qQW/56ivIncJcYomBungIx99gUpsEpcQaMNHgQ==",
+      "version": "34.3.12",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.19",
-        "victory-core": "37.3.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0"
+        "lodash": "^4.17.15",
+        "prop-types": "^15.5.8",
+        "victory-core": "^34.3.12"
       }
     },
     "node_modules/vlq": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "react-native-circular-progress": "1.3.7",
     "react-native-flip-editor": "github:biblemesh/react-native-flip-editor#7bb67786ef504ca5694b757f915b0e883e6d7f26",
     "react-native-gesture-handler": "~2.24.0",
-    "react-native-reanimated": "~3.19.1",
+    "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-simple-side-menu": "github:biblemesh/react-native-simple-side-menu#23df42cad42ccfb276d29140d853864ed1af57a3",
     "react-native-svg": "15.11.2",
@@ -143,8 +143,8 @@
     "stream": "0.0.2",
     "timers": "0.1.1",
     "uuid": "^9.0.1",
-    "victory": "37.3.6",
-    "victory-native": "41.20.2",
+    "victory": "34.1.3",
+    "victory-native": "34.1.0",
     "vm-browserify": "^1.1.2",
     "xml2js": "0.4.23"
   },
@@ -164,12 +164,5 @@
   },
   "engines": {
     "node": ">=20.0.0"
-  },
-  "expo": {
-    "install": {
-      "exclude": [
-        "react-native-reanimated"
-      ]
-    }
   }
 }


### PR DESCRIPTION
Reverts biblemesh/toad-reader-apps#49

It seems like the upgrade broke quite a few things, so we'll revert it for now. We can re-apply the update in the future, with some testing.