### PR TITLE
BM-17 expo set up

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -1,5 +1,4 @@
 /.expo/*
 /dist/*
 /node_modules/*
-/tenants/*
 /web-build/*

--- a/scripts/changeTenant.sh
+++ b/scripts/changeTenant.sh
@@ -68,7 +68,7 @@ else
 
     # copy tenant items to the base dir
     for TENANT_ITEM in "${TENANT_ITEMS[@]}" ; do
-      ln -s "$PWD/tenants/$TENANT_TO_SWITCH_TO/$TENANT_ITEM" "./$TENANT_ITEM";
+      ln -s "tenants/$TENANT_TO_SWITCH_TO/$TENANT_ITEM" "./$TENANT_ITEM";
     done
 
     # update src/utils/translations/current.json with the current language data


### PR DESCRIPTION
Related: https://github.com/biblemesh/ereader-development/issues/40

Fix a couple of issues relating to the switch to symlinks for tenant files (#43):

1. Absolute paths were causing the docker build to fail
2. Tenant files must now be included in the EAS build bundle in order to be correctly linked