### PR TITLE
remove react-native-reanimated

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -15,13 +15,6 @@ jest.mock('@react-native-async-storage/async-storage', () =>
   ),
 );
 
-// Mock react-native-reanimated
-jest.mock('react-native-reanimated', () => {
-  const Reanimated = jest.requireActual('react-native-reanimated/mock');
-  Reanimated.default.call = () => {};
-  return Reanimated;
-});
-
 // Mock Expo modules
 jest.mock('expo-constants', () => ({
   default: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
         "react-native-circular-progress": "1.3.7",
         "react-native-flip-editor": "github:biblemesh/react-native-flip-editor#7bb67786ef504ca5694b757f915b0e883e6d7f26",
         "react-native-gesture-handler": "~2.24.0",
-        "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-simple-side-menu": "github:biblemesh/react-native-simple-side-menu#23df42cad42ccfb276d29140d853864ed1af57a3",
         "react-native-svg": "15.11.2",
@@ -1423,20 +1422,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
       "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
-      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -16446,39 +16431,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
       "integrity": "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-reanimated": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz",
-      "integrity": "sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==",
-      "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
-        "@babel/plugin-transform-class-properties": "^7.0.0-0",
-        "@babel/plugin-transform-classes": "^7.0.0-0",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
-        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
-        "@babel/plugin-transform-template-literals": "^7.0.0-0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
-        "@babel/preset-typescript": "^7.16.7",
-        "convert-source-map": "^2.0.0",
-        "invariant": "^2.2.4",
-        "react-native-is-edge-to-edge": "1.1.7"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-reanimated/node_modules/react-native-is-edge-to-edge": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
-      "integrity": "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "react-native-circular-progress": "1.3.7",
     "react-native-flip-editor": "github:biblemesh/react-native-flip-editor#7bb67786ef504ca5694b757f915b0e883e6d7f26",
     "react-native-gesture-handler": "~2.24.0",
-    "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-simple-side-menu": "github:biblemesh/react-native-simple-side-menu#23df42cad42ccfb276d29140d853864ed1af57a3",
     "react-native-svg": "15.11.2",


### PR DESCRIPTION
closes https://github.com/biblemesh/ereader-development/issues/122

ios eas build : https://expo.dev/accounts/biblemesh/projects/biblemesh-activereader/builds/885dca18-6545-448e-8fe7-49793fa47540
android eas build: https://expo.dev/accounts/biblemesh/projects/biblemesh-activereader/builds/94c6daa6-6023-41d8-a813-4fa47f36884a

I tested the app on Expo Web and Android. The application opens, books can be downloaded, and the general menus work. Everything works fine. I asked Filip to test it on ios(1.1.6).