### PR TITLE
Update Amplitude

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "toad-reader-apps",
       "version": "1.0.0",
       "dependencies": {
-        "@amplitude/analytics-react-native": "^1.1.1",
+        "@amplitude/analytics-browser": "^2.36.4",
+        "@amplitude/analytics-react-native": "^1.5.47",
         "@babel/plugin-transform-react-jsx-source": "7.2.0",
         "@eva-design/eva": "2.1.1",
         "@expo/metro-runtime": "~5.0.5",
@@ -21,7 +22,6 @@
         "@sentry/react-native": "~6.14.0",
         "@shopify/flash-list": "1.7.6",
         "@ui-kitten/components": "5.1.2",
-        "amplitude-js": "^8.3.1",
         "babel-plugin-transform-remove-console": "6.9.4",
         "babel-preset-expo": "~13.0.0",
         "copy-to-clipboard": "^3.3.3",
@@ -127,28 +127,46 @@
         }
       }
     },
+    "node_modules/@amplitude/analytics-browser": {
+      "version": "2.36.4",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.36.4.tgz",
+      "integrity": "sha512-R/lhtbBXs3WXJG0GFetKDHD6KO4psoPdBq5x8fJ530TIGasiZxL7s0ZzzKt93sTsgM79vgEkViwteACPMz0J8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "2.41.4",
+        "@amplitude/plugin-autocapture-browser": "1.23.4",
+        "@amplitude/plugin-network-capture-browser": "1.9.4",
+        "@amplitude/plugin-page-url-enrichment-browser": "0.6.8",
+        "@amplitude/plugin-page-view-tracking-browser": "2.8.4",
+        "@amplitude/plugin-web-vitals-browser": "1.1.19",
+        "tslib": "^2.4.1"
+      }
+    },
     "node_modules/@amplitude/analytics-connector": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.6.4.tgz",
       "integrity": "sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q=="
     },
     "node_modules/@amplitude/analytics-core": {
-      "version": "2.40.2",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.40.2.tgz",
-      "integrity": "sha512-bKQyB0gFEmYiI1pHJSaCjXlml0NvQsx/S8RXoIVmI+pwh6hb1y6NlsHx4BJaYpUxw8/2ww+1UClSUMkP/aFNjQ==",
+      "version": "2.41.4",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.41.4.tgz",
+      "integrity": "sha512-sZi4fD6KSOUTvyMtBtCX8E/1VjUrS1VIShyJpKWoYKW55IF5y1/knVkhLzbycNKzMCOv/pl/vXHeXDqHy5eU9w==",
+      "license": "MIT",
       "dependencies": {
         "@amplitude/analytics-connector": "^1.6.4",
+        "@types/zen-observable": "0.8.3",
         "safe-json-stringify": "1.2.0",
         "tslib": "^2.4.1",
-        "zen-observable-ts": "^1.1.0"
+        "zen-observable": "0.10.0"
       }
     },
     "node_modules/@amplitude/analytics-react-native": {
-      "version": "1.5.42",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.5.42.tgz",
-      "integrity": "sha512-aNbOT/A2bGnDSK8iOpxFws66MNHI6SMWGVGh4wr4ejRXO8hlZYs5eCcyR2yR+eE6GDNhp0LKMnr4adgRbarY7g==",
+      "version": "1.5.47",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.5.47.tgz",
+      "integrity": "sha512-dNEzyPjLkYwee0jKm+n9xGijwXPo3/zfoWEh3yMxS9TsXP+ym1vIHhpS0CcYSBgCKJiiDjA8d2+Nnn1zUWypWA==",
+      "license": "MIT",
       "dependencies": {
-        "@amplitude/analytics-core": "2.40.2",
+        "@amplitude/analytics-core": "2.41.4",
         "@amplitude/ua-parser-js": "^0.7.31",
         "@react-native-async-storage/async-storage": "^1.17.11",
         "tslib": "^2.4.1"
@@ -169,12 +187,55 @@
         "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
-    "node_modules/@amplitude/types": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@amplitude/types/-/types-1.10.2.tgz",
-      "integrity": "sha512-I8qenRI7uU6wKNb9LiZrAosSHVoNHziXouKY81CrqxH9xhVTEIJFXeuCV0hbtBr0Al/8ejnGjQRx+S2SvU/pPg==",
-      "engines": {
-        "node": ">=10"
+    "node_modules/@amplitude/plugin-autocapture-browser": {
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-autocapture-browser/-/plugin-autocapture-browser-1.23.4.tgz",
+      "integrity": "sha512-yBRiZU21PrHpfKa26nDBtBkak1LxM4kp/S0ffMaDDB/Mo7sXAWCmSJjs8C+nUuKdIUpmkIl1EQvPQhC15ZV9YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "2.41.4",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-network-capture-browser": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-network-capture-browser/-/plugin-network-capture-browser-1.9.4.tgz",
+      "integrity": "sha512-jbIehDontSaiisAJRm/aVp8xV083JaqfVAlO1vJz/hpmctyfHFbnrTF2yEVaZ90/w7RQC/D7yJuedaSXFCjJBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "2.41.4",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-page-url-enrichment-browser": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-url-enrichment-browser/-/plugin-page-url-enrichment-browser-0.6.8.tgz",
+      "integrity": "sha512-q465BkvPw5NC573eDuIu+Mu4UiPr7CVmMP0NqBlavyzUkP2Nnj4ckpeEpod1CdH+jxUvqUz1w79EPkT+vpSDlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "2.41.4",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-page-view-tracking-browser": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.8.4.tgz",
+      "integrity": "sha512-lxqMHxZe6Wn82kOh1Fo1ihTKX+OkAsCzDLuzq5+x6JvEyLzZcNJDU4tQDlyr4XuPXE+pRSrHkg1aTUGkkU2zlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "2.41.4",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-web-vitals-browser": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-web-vitals-browser/-/plugin-web-vitals-browser-1.1.19.tgz",
+      "integrity": "sha512-c37a+BxvEuwVrEI2e0643pjkFA+ZdAqU+39Gy8u+ERrbtXubpgyxqFI2+WzGRVuOiV1eFbjQlMwiJoETF/TDzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "2.41.4",
+        "tslib": "^2.4.1",
+        "web-vitals": "5.1.0"
       }
     },
     "node_modules/@amplitude/ua-parser-js": {
@@ -193,18 +254,6 @@
       ],
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/@amplitude/utils": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@amplitude/utils/-/utils-1.10.2.tgz",
-      "integrity": "sha512-tVsHXu61jITEtRjB7NugQ5cVDd4QDzne8T3ifmZye7TiJeUfVRvqe44gDtf55A+7VqhDhyEIIXTA1iVcDGqlEw==",
-      "dependencies": {
-        "@amplitude/types": "^1.10.2",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -4867,7 +4916,8 @@
     "node_modules/@types/zen-observable": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
-      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
@@ -5300,19 +5350,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/amplitude-js": {
-      "version": "8.21.10",
-      "resolved": "https://registry.npmjs.org/amplitude-js/-/amplitude-js-8.21.10.tgz",
-      "integrity": "sha512-FUAnk+eFb9mOLOkwE3Dh1sVOeamuSLXs7AvfI3i81urq3T8L+aYiZE2jxS+e3+6v5Qcl6x5oBAsctSSNzfzLqg==",
-      "dependencies": {
-        "@amplitude/analytics-connector": "^1.4.6",
-        "@amplitude/ua-parser-js": "0.7.33",
-        "@amplitude/utils": "^1.10.2",
-        "@babel/runtime": "^7.28.6",
-        "blueimp-md5": "^2.19.0",
-        "query-string": "8.1.0"
       }
     },
     "node_modules/anser": {
@@ -5950,11 +5987,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/blueimp-md5": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
-      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w=="
     },
     "node_modules/bn.js": {
       "version": "5.2.3",
@@ -7335,14 +7367,6 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true
-    },
-    "node_modules/decode-uri-component": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
-      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
-      "engines": {
-        "node": ">=14.16"
-      }
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -9291,17 +9315,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/filter-obj": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
-      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/finalhandler": {
@@ -16163,22 +16176,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/query-string": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-8.1.0.tgz",
-      "integrity": "sha512-BFQeWxJOZxZGix7y+SByG3F36dA0AbTy9o6pSmKFcFz7DAj0re9Frkty3saBn3nHo3D0oZJ/+rx3r8H8r8Jbpw==",
-      "dependencies": {
-        "decode-uri-component": "^0.4.1",
-        "filter-obj": "^5.1.0",
-        "split-on-first": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/querystring-es3": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
@@ -17301,7 +17298,8 @@
     "node_modules/safe-json-stringify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
-      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg=="
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -17839,17 +17837,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/split-on-first": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
-      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sprintf-js": {
@@ -19757,6 +19744,12 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -20308,18 +20301,10 @@
       }
     },
     "node_modules/zen-observable": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "node_modules/zen-observable-ts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
-      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
-      "dependencies": {
-        "@types/zen-observable": "0.8.3",
-        "zen-observable": "0.8.15"
-      }
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.10.0.tgz",
+      "integrity": "sha512-iI3lT0iojZhKwT5DaFy2Ce42n3yFcLdFyOh01G7H0flMY60P8MJuVFEoJoNwXlmAyQ45GrjL6AcZmmlv8A5rbw==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "react-native-webview": "13.13.5"
   },
   "dependencies": {
-    "@amplitude/analytics-react-native": "^1.1.1",
+    "@amplitude/analytics-browser": "^2.36.4",
+    "@amplitude/analytics-react-native": "^1.5.47",
     "@babel/plugin-transform-react-jsx-source": "7.2.0",
     "@eva-design/eva": "2.1.1",
     "@expo/metro-runtime": "~5.0.5",
@@ -86,7 +87,6 @@
     "@sentry/react-native": "~6.14.0",
     "@shopify/flash-list": "1.7.6",
     "@ui-kitten/components": "5.1.2",
-    "amplitude-js": "^8.3.1",
     "babel-plugin-transform-remove-console": "6.9.4",
     "babel-preset-expo": "~13.0.0",
     "copy-to-clipboard": "^3.3.3",

--- a/src/utils/analytics.web.js
+++ b/src/utils/analytics.web.js
@@ -1,5 +1,12 @@
+import {
+  identify,
+  Identify,
+  init,
+  reset,
+  setUserId,
+  track,
+} from '@amplitude/analytics-browser';
 import Constants from 'expo-constants';
-import Amplitude from 'amplitude-js';
 
 import { isStaging, isBeta, getQueryString } from './toolbox';
 
@@ -7,7 +14,11 @@ const { AMPLITUDE_API_KEY } = Constants.expoConfig.extra;
 
 const on = !!(!__DEV__ && AMPLITUDE_API_KEY && !isStaging() && !isBeta());
 
-Amplitude.getInstance().init(AMPLITUDE_API_KEY);
+if (on) {
+  init(AMPLITUDE_API_KEY, null, {
+    minIdLength: 1,
+  });
+}
 
 export const logEvent = async ({ eventName, properties }) => {
   const query = getQueryString();
@@ -20,7 +31,7 @@ export const logEvent = async ({ eventName, properties }) => {
   }
 
   if (on) {
-    Amplitude.getInstance().logEvent(eventName, properties);
+    track(eventName, properties || {});
   } else if (__DEV__) {
     console.log('logEvent', eventName, properties);
   }
@@ -28,12 +39,15 @@ export const logEvent = async ({ eventName, properties }) => {
 
 export const setUser = async ({ userId = null, properties = {} } = {}) => {
   if (on) {
-    Amplitude.getInstance().setUserId(userId && `${userId}`);
-
     if (userId) {
-      Amplitude.getInstance().setUserProperties(properties);
+      setUserId(userId);
+      const identifyObj = new Identify();
+      for (let property in properties) {
+        identifyObj.set(property, properties[property]);
+      }
+      identify(identifyObj);
     } else {
-      Amplitude.getInstance().regenerateDeviceId();
+      reset();
     }
   } else if (__DEV__) {
     console.log('setUser', userId, properties);

--- a/src/utils/analytics.web.js
+++ b/src/utils/analytics.web.js
@@ -1,58 +1,41 @@
-import Constants from "expo-constants"
-import Amplitude from "amplitude-js"
+import Constants from 'expo-constants';
+import Amplitude from 'amplitude-js';
 
-import { isStaging, isBeta, getQueryString } from './toolbox'
+import { isStaging, isBeta, getQueryString } from './toolbox';
 
-const {
-  AMPLITUDE_API_KEY,
-} = Constants.expoConfig.extra
+const { AMPLITUDE_API_KEY } = Constants.expoConfig.extra;
 
-const on = !!(!__DEV__ && AMPLITUDE_API_KEY && !isStaging() && !isBeta())
+const on = !!(!__DEV__ && AMPLITUDE_API_KEY && !isStaging() && !isBeta());
 
-Amplitude.getInstance().init(AMPLITUDE_API_KEY)
+Amplitude.getInstance().init(AMPLITUDE_API_KEY);
 
 export const logEvent = async ({ eventName, properties }) => {
+  const query = getQueryString();
 
-  const query = getQueryString()
-
-  if(query.widget) {
+  if (query.widget) {
     properties = {
       ...properties,
       widget: true,
-    }
+    };
   }
 
-  if(on) {
-
-    Amplitude.getInstance().logEvent(
-      eventName,
-      properties,
-    )
-
-  } else if(__DEV__) {
-
-    console.log('logEvent', eventName, properties)
-
+  if (on) {
+    Amplitude.getInstance().logEvent(eventName, properties);
+  } else if (__DEV__) {
+    console.log('logEvent', eventName, properties);
   }
+};
 
-}
+export const setUser = async ({ userId = null, properties = {} } = {}) => {
+  if (on) {
+    Amplitude.getInstance().setUserId(userId && `${userId}`);
 
-export const setUser = async ({ userId=null, properties={} }={}) => {
-
-  if(on) {
-
-    Amplitude.getInstance().setUserId(userId && `${userId}`)
-
-    if(userId) {
-      Amplitude.getInstance().setUserProperties(properties)
+    if (userId) {
+      Amplitude.getInstance().setUserProperties(properties);
     } else {
-      Amplitude.getInstance().regenerateDeviceId()
+      Amplitude.getInstance().regenerateDeviceId();
     }
-
-  } else if(__DEV__) {
-
-    console.log('setUser', userId, properties)
-
+  } else if (__DEV__) {
+    console.log('setUser', userId, properties);
   }
-
-}
+};


### PR DESCRIPTION
Changed to use Amplitude's browser library with the [same underlying library](https://github.com/amplitude/Amplitude-TypeScript) as the react native one, which is why `src/utils/analytics.web.js` looks like [/src/utils/analytics.js](https://github.com/biblemesh/toad-reader-apps/blob/f48de724e820d8f2dfc8e5e237e4d347fe35e9e6/src/utils/analytics.js). I've tested this update on the production test site. I have builds for Android and iOS in progress, but the actual lock file version change of `@amplitude/analytics-react-native` is from 1.5.42 to 1.5.47 so unlikely to cause an issue.