### PR TITLE
add expo-build-properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "expo-asset": "~11.1.7",
         "expo-av": "~15.1.7",
         "expo-blur": "~14.1.5",
+        "expo-build-properties": "~0.14.8",
         "expo-camera": "~16.1.11",
         "expo-checkbox": "~4.1.4",
         "expo-clipboard": "~7.1.5",
@@ -8516,6 +8517,49 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-build-properties": {
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-0.14.8.tgz",
+      "integrity": "sha512-GTFNZc5HaCS9RmCi6HspCe2+isleuOWt2jh7UEKHTDQ9tdvzkIoWc7U6bQO9lH3Mefk4/BcCUZD/utl7b1wdqw==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/expo-build-properties/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/expo-camera": {
       "version": "16.1.11",
       "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-16.1.11.tgz",
@@ -9153,6 +9197,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/fastest-stable-stringify": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "expo-asset": "~11.1.7",
     "expo-av": "~15.1.7",
     "expo-blur": "~14.1.5",
+    "expo-build-properties": "~0.14.8",
     "expo-camera": "~16.1.11",
     "expo-checkbox": "~4.1.4",
     "expo-clipboard": "~7.1.5",


### PR DESCRIPTION
closes https://github.com/biblemesh/ereader-development/issues/118

android build: https://expo.dev/accounts/biblemesh/projects/biblemesh-activereader/builds/51188c9d-03ef-41a7-a2d9-8855d6eb4f72

I reproduced the warning on the previous Android build before adding expo-build-properties. After enabling ProGuard/R8 and uploading a new build with version code 113 (1.1.6), the warning no longer appeared in Google Play Console. I also published the new Android internal testing release successfully.

please check PR => https://github.com/biblemesh/ereader-development/pull/124